### PR TITLE
Updates for handling Ansible 2.2 changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ default_routemap_state: present
 default_static_route_state: present
 default_static_route_dist: 1
 default_static_route_tag: 0
+
+resource_version: '2.2'

--- a/eos_module.yml
+++ b/eos_module.yml
@@ -21,6 +21,25 @@
         username: "{{ username | default(omit) }}"
       when: module == 'eos_command'
 
+    # Call the eos_config module if module is set to eos_config
+    - name: "{{ description | default('config playbook task') }}"
+      eos_config:
+        lines: "{{ lines | default(['']) }}"
+        parents: "{{ parents | default(omit) }}"
+        before: "{{ before | default(omit) }}"
+        after: "{{ after | default(omit) }}"
+        match: "{{ match | default('none')}}"
+        auth_pass: "{{ auth_pass | default(omit) }}"
+        authorize: "{{ authorize | default(omit) }}"
+        host: "{{ host | default(omit) }}"
+        password: "{{ password | default(omit) }}"
+        port: "{{ port | default(omit) }}"
+        provider: "{{ provider | default(omit) }}"
+        transport: "cli"
+        use_ssl: "{{ use_ssl | default(omit) }}"
+        username: "{{ username | default(omit) }}"
+      when: module == 'eos_config'
+
     # Call the eos_template module if module is set to eos_template
     - name: "{{ description | default('template playbook task') }}"
       eos_template:
@@ -35,4 +54,6 @@
         transport: "cli"
         use_ssl: "{{ use_ssl | default(omit) }}"
         username: "{{ username | default(omit) }}"
-      when: module == 'eos_template'
+      when: module == 'eos_template' and
+            (ansible_version.major < 2 or
+             (ansible_version.major == 2 and ansible_version.minor < 2))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# Determine what resources we will use for running the role:
+# If using Ansible 2.1 or lower, we can use eos_template
+# If using Ansible 2.2 or higher, we must use eos_config
+# resource_version is set to 2.2 by default (since most users will be
+# on updated versions), change it if we're running 2.1 or lower.'
+- set_fact:
+    resource_version: '2.1'
+  when: ansible_version.major < 2 or
+        (ansible_version.major == 2 and ansible_version.minor < 2)
+
 - name: Gather EOS configuration
   eos_command:
     commands: 'show running-config all | exclude \.\*'
@@ -21,43 +31,6 @@
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined
 
-- name: Arista EOS Routemap resources
-  eos_template:
-    src: routemaps.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when:
-    item.name is defined and
-    item.action is defined and
-    item.seqno is defined
-  with_items: "{{ routemaps | default([]) }}"
-
-- name: Arista EOS IPv4 Static Route resources
-  eos_template:
-    src: ipv4_static_routes.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when:
-    item.ip_dest is defined and
-    item.next_hop is defined
-  with_items: "{{ ipv4_static_routes | default([]) }}"
+# Import the resource tasks based on the version of ansible in use
+- name: Include the Arista EOS Routemap resources
+  include: "tasks/resources{{ resource_version }}.yml"

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -1,0 +1,43 @@
+# Perform the EOS Routemap tasks under Ansible 2.1 or earlier
+# using the Ansible eos_template module
+
+- name: Arista EOS Routemap resources (Ansible <= 2.1)
+  eos_template:
+    src: routemaps.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when:
+    item.name is defined and
+    item.action is defined and
+    item.seqno is defined
+  with_items: "{{ routemaps | default([]) }}"
+
+- name: Arista EOS IPv4 Static Route resources (Ansible <= 2.1)
+  eos_template:
+    src: ipv4_static_routes.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when:
+    item.ip_dest is defined and
+    item.next_hop is defined
+  with_items: "{{ ipv4_static_routes | default([]) }}"

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -1,0 +1,43 @@
+# Perform the EOS Routemap tasks under Ansible 2.2 or later
+# using the Ansible eos_config module
+
+- name: Arista EOS Routemap resources (Ansible >= 2.2)
+  eos_config:
+    src: routemaps.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when:
+    item.name is defined and
+    item.action is defined and
+    item.seqno is defined
+  with_items: "{{ routemaps | default([]) }}"
+
+- name: Arista EOS IPv4 Static Route resources (Ansible >= 2.2)
+  eos_config:
+    src: ipv4_static_routes.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when:
+    item.ip_dest is defined and
+    item.next_hop is defined
+  with_items: "{{ ipv4_static_routes | default([]) }}"

--- a/test/testcases/routemaps.yml
+++ b/test/testcases/routemaps.yml
@@ -116,7 +116,7 @@ testcases:
          continue 36
     absent: |
       route-map newmap05 permit 35
-         continute 86
+         continue 86
 
   - name: Delete routemap continue
     arguments:
@@ -134,7 +134,7 @@ testcases:
       route-map newmap06 permit 36
     absent: |
       route-map newmap06 permit 36
-         continute 37
+         continue 37
 
   - name: Set routemap match as
     arguments:
@@ -449,4 +449,4 @@ testcases:
          description newmap23 will be changed
          match as 53
          match metric 103
-         match distance 40
+         set distance 40


### PR DESCRIPTION
Put tasks for eos_template and eos_config into separate resource
files, then import those task files into main according to the
version of Ansible being used.

Update testcases for typos, test specification errors
